### PR TITLE
Improve nix-shell documentation

### DIFF
--- a/source/faq.rst
+++ b/source/faq.rst
@@ -73,7 +73,8 @@ Push to cachix:
 
 .. code:: shell-session
 
-    $ nix-store -qR --include-outputs $(nix-instantiate shell.nix) | cachix push mycache
+    $ nix-store --query --references $(nix-instantiate shell.nix) | xargs nix-store --realise | xargs nix-store --query --requisites | cachix push mycache
+
 
 How to disable binary caches when working offline?
 --------------------------------------------------


### PR DESCRIPTION
This is an update on how to cache nix-shell dependencies as discussed in https://github.com/NixOS/nixpkgs/issues/95191

This reduces the transitive set that is cached for **mkShell** to what is needed to run the shell.
The previous documentation cached **runtime** & **build** closure which was huge.

For my project here is the noticeable difference:

```bash
 nix-store --query --references $(nix-instantiate shell.nix) | xargs nix-store --realise | xargs nix-store --query --requisites | wc -l
warning: you did not specify '--add-root'; the result might be removed by the garbage collector
warning: you did not specify '--add-root'; the result might be removed by the garbage collector
332
```

vs
```
nix-store -qR --include-outputs $(nix-instantiate shell.nix) | wc -l
warning: you did not specify '--add-root'; the result might be removed by the garbage collector
4788
```

**332** vs. **4788**