### PR TITLE
Rewrite hydra.rst to mention RunCommand hooks

### DIFF
--- a/source/continuous-integration-setup/hydra.rst
+++ b/source/continuous-integration-setup/hydra.rst
@@ -3,11 +3,48 @@ Hydra
 
 .. source https://github.com/tbenst/nix-data-hydra/pull/2/files#diff-3367727976c111f36e7d3210944788ba
 
+There are two options for pushing data to cachix after builds: Configure Hydra with a static or dynamic [`RunCommand`](https://github.com/NixOS/hydra/blob/master/doc/manual/src/plugins/RunCommand.md) script, or configure a global `post-build-hook` in Nix.
+
+Either way, you need to create binary cache on https://app.cachix.org and generate a auth token and/or signing key. Then, create a secret file ``/etc/cachix/cachix.dhall`` on all machines with the following contents::
+
+    { authToken = "XXX" -- this one is needed only for private caches
+    , binaryCaches =
+        [ { name = "mycache"
+          , secretKey = "XXX-SIGNING_KEY"
+          }
+        ]
+    }
+
+
+RunCommand
+----------
+
+Add the following to your hydra configuration (assuming Hydra is configured with the NixOS module):
+
+.. code:: nix
+
+    services.hydra.extraConfig = ''
+      <runcommand>
+        job = home:mybuild:*
+        command = ${pkgs.writeShellApplication {
+        name = "upload-to-cachix";
+        runtimeInputs = [pkgs.jq pkgs.cachix];
+        text = ''
+          set -xeu
+          jq -r '.outputs[].path' "$HYDRA_JSON" | xargs cachix --config ${config.age.secrets.hydra-ci.path} push mycache
+        '';
+      }}/bin/upload-to-cachix
+      </runcommand>
+    ''
+
+This script runs after every Hydra build job.
+
+post-build-hook
+---------------
+
 You'll need to deploy all build machines with a `post build hook <https://nixos.org/manual/nix/stable/advanced-topics/post-build-hook.html>`_. 
 
-1. Create new binary cache on https://app.cachix.org and generate a signing key
-
-2. Assuming Hydra is deployed with NixOS, here's a NixOS module to configure Cachix:
+Assuming Hydra is deployed with NixOS, here's a NixOS module to configure Cachix:
 
 .. code:: nix
 
@@ -35,14 +72,3 @@ You'll need to deploy all build machines with a `post build hook <https://nixos.
       '';
     }
 
-3. Make sure to create a secret file ``/etc/cachix/cachix.dhall`` on all machines with the following contents::
-
-    { authToken = "XXX" -- this one is needed only for private caches
-    , binaryCaches =
-        [ { name = "mycache"
-          , secretKey = "XXX-SIGNING_KEY"
-          }
-        ]
-    }
-
-4. Replace ``mycache`` in above files with name of your new binary cache


### PR DESCRIPTION
This provides an alternative configuration for hydra jobs pushing to cachix (namely, the configuration that I ended up using (-:).

Hope this is useful to somebody else, too.