### PR TITLE
Update example for pushing flake dev shells

### DIFF
--- a/source/pushing.rst
+++ b/source/pushing.rst
@@ -96,5 +96,5 @@ Pushing shell environment
 
 .. code:: shell-session
 
-  $ nix develop --profile dev-profile 
+  $ nix develop --profile dev-profile -c true
   $ cachix push mycache dev-profile


### PR DESCRIPTION
Don't actually *stay* in the shell -- this makes the example easier to use in scripts etc.