### PR TITLE
Mark the flakes install as a code snippet

### DIFF
--- a/source/installation.rst
+++ b/source/installation.rst
@@ -14,10 +14,11 @@ With `Nix installed <https://nix.dev/tutorials/install-nix.html>`_::
 Flakes
 ------
 
+::
+
     $ nix profile install --accept-flake-config nixpkgs#cachix
 
 Using Nixpkgs or NixOS
 ----------------------
 
 Using ``pkgs.cachix`` attribute will install the latest stable version.
-


### PR DESCRIPTION
The install command for flakes wasn't marked as a code snippet, so it wasn't being rendered correctly in the docs. This change fixes it so that the command renders as a code snippet.