### PR TITLE
docs: Fix code formatting

### DIFF
--- a/source/faq.rst
+++ b/source/faq.rst
@@ -119,6 +119,6 @@ b) You didn't set correct auth token via ``netrc`` for a private binary cache. S
 How can I check if my auth token works?
 ---------------------------------------
 
-```
-$ curl -v -H "Authorization: Bearer <token>" https://app.cachix.org/api/v1/user
-```
+.. code:: shell-session
+
+    $ curl -v -H "Authorization: Bearer <token>" https://app.cachix.org/api/v1/user

--- a/source/faq.rst
+++ b/source/faq.rst
@@ -121,4 +121,4 @@ How can I check if my auth token works?
 
 .. code:: shell-session
 
-    $ curl -v -H "Authorization: Bearer <token>" https://app.cachix.org/api/v1/user
+    $ curl -v -H "Authorization: Bearer ${CACHIX_AUTH_TOKEN}" https://app.cachix.org/api/v1/user


### PR DESCRIPTION
The "```" formatting is not valid in RST.

I believe there's still a bug in this code, because I always get a HTTP 401 Unauthorized response from this endpoint.