### PR TITLE
Document custom CA certificate environment variables

### DIFF
--- a/source/faq.rst
+++ b/source/faq.rst
@@ -155,11 +155,6 @@ point Cachix at your certificate bundle using one of the following environment v
 ``SSL_CERT_DIR``
     Path to a directory of PEM certificates (each file must contain a single certificate).
 
-``SYSTEM_CERTIFICATE_PATH``
-    Path to a directory of PEM certificates. Useful when running as a user without
-    root privileges on systems where the default trust store is not readable or not
-    in a standard location.
-
 Example:
 
 .. code:: shell-session

--- a/source/faq.rst
+++ b/source/faq.rst
@@ -138,3 +138,35 @@ For cache authentication tokens:
 .. code:: shell-session
 
     $ curl -s --netrc-file ~/.config/nix/netrc https://mycache.cachix.org/nix-cache-info
+
+
+How do I supply a custom CA certificate?
+----------------------------------------
+
+By default, Cachix loads trusted certificates from the system store
+(``/etc/ssl/certs`` on Linux, the keychain on macOS, the system store on Windows).
+
+If you are behind a TLS intercepting corporate proxy or use your own certificate authority,
+point Cachix at your certificate bundle using one of the following environment variables:
+
+``SSL_CERT_FILE``
+    Path to a PEM bundle containing one or more trusted certificates.
+
+``SSL_CERT_DIR``
+    Path to a directory of PEM certificates (each file must contain a single certificate).
+
+``SYSTEM_CERTIFICATE_PATH``
+    Path to a directory of PEM certificates. Useful when running as a user without
+    root privileges on systems where the default trust store is not readable or not
+    in a standard location.
+
+Example:
+
+.. code:: shell-session
+
+    $ export SSL_CERT_FILE=/path/to/corporate-ca-bundle.pem
+    $ cachix push mycache ./result
+
+Note that ``cachix`` does not currently read ``NIX_SSL_CERT_FILE``.
+If you have configured Nix with ``NIX_SSL_CERT_FILE``, set ``SSL_CERT_FILE``
+to the same path so that ``cachix`` uses the same trust store.


### PR DESCRIPTION
## Summary
- Add FAQ entry explaining how to supply a custom CA bundle to ``cachix`` via ``SSL_CERT_FILE``, ``SSL_CERT_DIR``, and ``SYSTEM_CERTIFICATE_PATH``
- Cover the common case of being behind a TLS intercepting corporate proxy or using a private certificate authority
- Note that ``cachix`` does not read ``NIX_SSL_CERT_FILE``, so users who configured Nix that way need to also set ``SSL_CERT_FILE``

Closes cachix/cachix#702

## Test plan
- [ ] ``make html`` builds without warnings
- [ ] FAQ entry renders correctly and is reachable from the FAQ page

🤖 Generated with [Claude Code](https://claude.com/claude-code)